### PR TITLE
Support multiple operations inside `${}` and improved error handling

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -16,58 +16,96 @@ func TestParser(t *testing.T) {
 			String: `Buildkite... ${HELLO_WORLD} ${ANOTHER_VAR:-🏖}`,
 			Expected: []interpolate.ExpressionItem{
 				{Text: "Buildkite... "},
-				{Expansion: interpolate.VariableExpansion{
-					Identifier: "HELLO_WORLD",
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "HELLO_WORLD",
+					},
+				},
 				{Text: " "},
-				{Expansion: interpolate.EmptyValueExpansion{
-					Identifier: "ANOTHER_VAR",
-					Content: interpolate.Expression([]interpolate.ExpressionItem{{
-						Text: "🏖",
-					}}),
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "ANOTHER_VAR",
+						Expressions: []interpolate.Expansion{
+							interpolate.EmptyValueExpansion{
+								Identifier: "ANOTHER_VAR",
+								Content: interpolate.Expression([]interpolate.ExpressionItem{
+									{Text: "🏖"},
+								}),
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			String: `${TEST1:- ${TEST2:-$TEST3}}`,
 			Expected: []interpolate.ExpressionItem{
-				{Expansion: interpolate.EmptyValueExpansion{
-					Identifier: "TEST1",
-					Content: interpolate.Expression([]interpolate.ExpressionItem{
-						{Text: " "},
-						{Expansion: interpolate.EmptyValueExpansion{
-							Identifier: "TEST2",
-							Content: interpolate.Expression([]interpolate.ExpressionItem{
-								{Expansion: interpolate.VariableExpansion{
-									Identifier: "TEST3",
-								}},
-							}),
-						}},
-					}),
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "TEST1",
+						Expressions: []interpolate.Expansion{
+							interpolate.EmptyValueExpansion{
+								Identifier: "TEST1",
+								Content: interpolate.Expression([]interpolate.ExpressionItem{
+									{Text: " "},
+									{
+										Expansion: interpolate.VariableExpansion{
+											Identifier: "TEST2",
+											Expressions: []interpolate.Expansion{
+												interpolate.EmptyValueExpansion{
+													Identifier: "TEST2",
+													Content: interpolate.Expression([]interpolate.ExpressionItem{
+														{
+															Expansion: interpolate.VariableExpansion{
+																Identifier: "TEST3",
+															},
+														},
+													}),
+												}},
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			String: `${HELLO_WORLD-blah}`,
 			Expected: []interpolate.ExpressionItem{
-				{Expansion: interpolate.UnsetValueExpansion{
-					Identifier: "HELLO_WORLD",
-					Content: interpolate.Expression([]interpolate.ExpressionItem{{
-						Text: "blah",
-					}}),
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "HELLO_WORLD",
+						Expressions: []interpolate.Expansion{
+							interpolate.UnsetValueExpansion{
+								Identifier: "HELLO_WORLD",
+								Content: interpolate.Expression([]interpolate.ExpressionItem{
+									{Text: "blah"},
+								}),
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			String: `\\${HELLO_WORLD-blah}`,
 			Expected: []interpolate.ExpressionItem{
 				{Text: `\\`},
-				{Expansion: interpolate.UnsetValueExpansion{
-					Identifier: "HELLO_WORLD",
-					Content: interpolate.Expression([]interpolate.ExpressionItem{{
-						Text: "blah",
-					}}),
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "HELLO_WORLD",
+						Expressions: []interpolate.Expansion{
+							interpolate.UnsetValueExpansion{
+								Identifier: "HELLO_WORLD",
+								Content: interpolate.Expression([]interpolate.ExpressionItem{
+									{Text: "blah"},
+								}),
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -89,63 +127,105 @@ func TestParser(t *testing.T) {
 		{
 			String: `${HELLO_WORLD:1}`,
 			Expected: []interpolate.ExpressionItem{
-				{Expansion: interpolate.SubstringExpansion{
-					Identifier: "HELLO_WORLD",
-					Offset:     1,
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "HELLO_WORLD",
+						Expressions: []interpolate.Expansion{
+							interpolate.SubstringExpansion{
+								Identifier: "HELLO_WORLD",
+								Offset:     1,
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			String: `${HELLO_WORLD: -1}`,
 			Expected: []interpolate.ExpressionItem{
-				{Expansion: interpolate.SubstringExpansion{
-					Identifier: "HELLO_WORLD",
-					Offset:     -1,
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "HELLO_WORLD",
+						Expressions: []interpolate.Expansion{
+							interpolate.SubstringExpansion{
+								Identifier: "HELLO_WORLD",
+								Offset:     -1,
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			String: `${HELLO_WORLD:-1}`,
 			Expected: []interpolate.ExpressionItem{
-				{Expansion: interpolate.EmptyValueExpansion{
-					Identifier: "HELLO_WORLD",
-					Content: interpolate.Expression([]interpolate.ExpressionItem{{
-						Text: "1",
-					}}),
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "HELLO_WORLD",
+						Expressions: []interpolate.Expansion{
+							interpolate.EmptyValueExpansion{
+								Identifier: "HELLO_WORLD",
+								Content: interpolate.Expression([]interpolate.ExpressionItem{
+									{Text: "1"},
+								}),
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			String: `${HELLO_WORLD:1:7}`,
 			Expected: []interpolate.ExpressionItem{
-				{Expansion: interpolate.SubstringExpansion{
-					Identifier: "HELLO_WORLD",
-					Offset:     1,
-					Length:     7,
-					HasLength:  true,
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "HELLO_WORLD",
+						Expressions: []interpolate.Expansion{
+							interpolate.SubstringExpansion{
+								Identifier: "HELLO_WORLD",
+								Offset:     1,
+								Length:     7,
+								HasLength:  true,
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			String: `${HELLO_WORLD:1:-7}`,
 			Expected: []interpolate.ExpressionItem{
-				{Expansion: interpolate.SubstringExpansion{
-					Identifier: "HELLO_WORLD",
-					Offset:     1,
-					Length:     -7,
-					HasLength:  true,
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "HELLO_WORLD",
+						Expressions: []interpolate.Expansion{
+							interpolate.SubstringExpansion{
+								Identifier: "HELLO_WORLD",
+								Offset:     1,
+								Length:     -7,
+								HasLength:  true,
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			String: `${HELLO_WORLD?Required}`,
 			Expected: []interpolate.ExpressionItem{
-				{Expansion: interpolate.RequiredExpansion{
-					Identifier: "HELLO_WORLD",
-					Message: interpolate.Expression([]interpolate.ExpressionItem{
-						{Text: "Required"},
-					}),
-				}},
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "HELLO_WORLD",
+						Expressions: []interpolate.Expansion{
+							interpolate.RequiredExpansion{
+								Identifier: "HELLO_WORLD",
+								Message: interpolate.Expression([]interpolate.ExpressionItem{
+									{Text: "Required"},
+								}),
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -165,6 +245,30 @@ func TestParser(t *testing.T) {
 			Expected: []interpolate.ExpressionItem{
 				{Text: `$(`},
 				{Text: `echo hello world)`},
+			},
+		},
+		{
+			String: `${DATA:1:3-Tuesday}`,
+			Expected: []interpolate.ExpressionItem{
+				{
+					Expansion: interpolate.VariableExpansion{
+						Identifier: "DATA",
+						Expressions: []interpolate.Expansion{
+							interpolate.SubstringExpansion{
+								Identifier: "DATA",
+								Offset:     1,
+								Length:     3,
+								HasLength:  true,
+							},
+							interpolate.UnsetValueExpansion{
+								Identifier: "DATA",
+								Content: interpolate.Expression([]interpolate.ExpressionItem{
+									{Text: "Tuesday"},
+								}),
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Details

### Multiple operations in one expression  
The internal parsing and data structures have been refactored to allow multiple nested expansions within a single `${}` interpolation. This flexibility enables combining operations such as substring and default value assignment in one expression.

### Issue resolution  
This change addresses [issue #2](https://github.com/mfridman/interpolate/issues/2), which requested support for multiple conditions inside a single variable expansion.

### Improved error messaging  
When an invalid offset is provided for substring operations (e.g., non-numeric values), the error message has been clarified to:  
`Offset is not a number, the resulting value is ""`

### Backward compatibility  
Existing templates and expansions remain fully supported. The only breaking change is internal: the `Expansion` structure now supports a slice of nested expansions instead of a single one, enabling the new feature.

## Impact

- Enables more expressive variable interpolations with combined operations.
- Improves reliability by providing clearer feedback on parsing errors in cases with SubstringExpansion.
- Testing has been expanded to cover new scenarios with chained extensions.

## Example

**Now you can write:**
```
${DATA:1-default}
```